### PR TITLE
fix-user-avatar

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -6,6 +6,7 @@
 parameters:
     site_name: 'SnowTricks'
     app.jwtsecret: '%env(JWT_SECRET)%'
+    images_directory: '%kernel.project_dir%/public/images/uploads/'
     
 services:
     # default configuration for services in *this* file

--- a/migrations/Version20231030002948.php
+++ b/migrations/Version20231030002948.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20231030002948 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE user ADD avatar VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE user DROP avatar');
+    }
+}

--- a/migrations/Version20231030003529.php
+++ b/migrations/Version20231030003529.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20231030003529 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE user CHANGE reset_token reset_token VARCHAR(100) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE user CHANGE reset_token reset_token VARCHAR(100) NOT NULL');
+    }
+}

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -12,6 +12,10 @@ class LoginController extends AbstractController
     #[Route('/login', name: 'app_login')]
     public function index(AuthenticationUtils $authenticationUtils): Response
     {
+        if ($this->getUser()) {
+            return $this->redirectToRoute('app_home');
+        }
+
         // get the login error if there is one
         $error = $authenticationUtils->getLastAuthenticationError();
 

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -8,6 +8,7 @@ use App\Form\RegistrationType;
 use App\Form\ResetPasswordRequestFormType;
 use App\Repository\UserRepository;
 use App\Service\JWTService;
+use App\Service\PictureService;
 use App\Service\SendEmailService;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -22,7 +23,7 @@ use Symfony\Component\Security\Csrf\TokenGenerator\TokenGeneratorInterface;
 class SecurityController extends AbstractController
 {
     #[Route('/inscription', name: 'security_registration')]
-    public function registration(Request $request, UserPasswordHasherInterface $userPasswordHasher, EntityManagerInterface $entityManager, SendEmailService $email, JWTService $jwt): Response
+    public function registration(Request $request, UserPasswordHasherInterface $userPasswordHasher, EntityManagerInterface $entityManager, SendEmailService $email, JWTService $jwt, PictureService $pictureService): Response
     {
         $user = new User;
         $form = $this->createForm(RegistrationType::class, $user);
@@ -36,8 +37,18 @@ class SecurityController extends AbstractController
                     $form->get('plainPassword')->getData()
                 )
             );
+
             $user->setRoles(['ROLE_USER']);
             $user->setIsVerified(false);
+
+            // upload avatar
+            $avatar = $form->get('avatar')->getData();
+            $folder = 'avatars';
+
+            $field = $pictureService->add($avatar, $folder, 300, 300);
+
+            $user->setAvatar($field);
+
 
             $entityManager->persist($user);
             $entityManager->flush();

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -42,11 +42,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(type: 'boolean')]
     private $isVerified = false;
 
-    #[ORM\Column(type: 'string', length: 100)]
+    #[ORM\Column(type: 'string', length: 100, nullable: true)]
     private $resetToken;
 
     #[ORM\OneToMany(mappedBy: 'user', targetEntity: Comment::class)]
     private Collection $commentList;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $avatar = null;
 
     public function __construct()
     {
@@ -185,6 +188,18 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
                 $comment->setUser(null);
             }
         }
+
+        return $this;
+    }
+
+    public function getAvatar(): ?string
+    {
+        return $this->avatar;
+    }
+
+    public function setAvatar(?string $avatar): static
+    {
+        $this->avatar = $avatar;
 
         return $this;
     }

--- a/src/Form/RegistrationType.php
+++ b/src/Form/RegistrationType.php
@@ -8,6 +8,7 @@ use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -93,6 +94,11 @@ class RegistrationType extends AbstractType
                 'invalid_message' => 'Les mots de passe doivent être identique.',
                 'mapped' => false,
             ])
+            ->add('avatar', FileType::class, [
+                'label' => 'Télécharger votre avatar',
+                'mapped' => false,
+                'required' => false,
+            ] )
         ;
     }
 

--- a/src/Service/PictureService.php
+++ b/src/Service/PictureService.php
@@ -66,7 +66,7 @@ Class PictureService
 
         imagecopyresampled($resizePicture, $pictureSource, 0, 0, $src_x, $src_y, $width, $heigth, $squareSize, $squareSize);
 
-        $path = $this->params->get('image_directory').$folder;
+        $path = $this->params->get('images_directory').$folder;
 
         if (!file_exists(($path.'/mini/'))) {
             mkdir($path.'/mini/', 0755, true);

--- a/src/Service/PictureService.php
+++ b/src/Service/PictureService.php
@@ -17,7 +17,7 @@ Class PictureService
     /**
      * Function to add a picture with a uniqid
      */
-    public function add(UploadedFile $picture, ?string $folder = '', ?int $width = 250, ?int $heigth = 250)
+    public function add(UploadedFile $picture, ?string $folder = '', ?int $width = 250, ?int $heigth = 250):string 
     {
         $field = md5(uniqId(rand(), true)).'.png';
 
@@ -79,7 +79,8 @@ Class PictureService
 
     }
 
-    public function delete(string $field, ?string $folder = '', ?int $width = 250, ?int $heigth =250) {
+    public function delete(string $field, ?string $folder = '', ?int $width = 250, ?int $heigth =250):bool
+    {
         if ($field !== 'default-avatar.png') {
             $success = false;
             $path = $this->params->get('images_directory').$folder;

--- a/src/Service/PictureService.php
+++ b/src/Service/PictureService.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Service;
+
+use Exception;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+Class PictureService 
+{
+    private $params;
+
+    public function __construct(ParameterBagInterface $params) {
+        $this->params = $params;
+    }
+
+    /**
+     * Function to add a picture with a uniqid
+     */
+    public function add(UploadedFile $picture, ?string $folder = '', ?int $width = 250, ?int $heigth = 250)
+    {
+        $field = md5(uniqId(rand(), true)).'.png';
+
+        $pictureDatas = getImageSize($picture);
+
+        if ($pictureDatas === false) {
+            throw new Exception('Format d\'image incorrect');
+        }
+
+        switch($pictureDatas['mime']) {
+            case 'image/png':
+                $pictureSource = imagecreatefrompng($picture);
+                break;
+            case 'image/jpeg':
+                $pictureSource = imagecreatefromjpeg($picture);
+                break;  
+            case 'image/webp':
+                $pictureSource = imagecreatefromwebp($picture);
+                break;
+            default:
+                throw new Exception('Format d\image non valide. Format pris en charge: jpeg, png, webp.');
+        }
+
+        $imageWidth = $pictureDatas[0];
+        $imageHeight = $pictureDatas[1];
+
+        switch ($imageWidth <=> $imageHeight) {
+            case -1: // portrait
+                $squareSize = $imageWidth;
+                $src_x = 0;
+                $src_y = ($imageHeight - $squareSize) / 2;
+                break;
+            case 0: // carré
+                $squareSize = $imageWidth;
+                $src_x = 0;
+                $src_y = 0;
+                break;
+            case 1: // paysage
+                $squareSize = $imageWidth;
+                $src_x = ($imageHeight - $squareSize) / 2;
+                $src_y = 0;
+                break;
+        }
+
+        $resizePicture = imagecreatetruecolor($width, $heigth);
+
+        imagecopyresampled($resizePicture, $pictureSource, 0, 0, $src_x, $src_y, $width, $heigth, $squareSize, $squareSize);
+
+        $path = $this->params->get('image_directory').$folder;
+
+        if (!file_exists(($path.'/mini/'))) {
+            mkdir($path.'/mini/', 0755, true);
+        }
+
+        imagepng($resizePicture, $path.'/mini/'.$width.'x'.$heigth.'-'.$field);
+        $picture->move($path.'/',$field);
+
+        return $field;
+
+    }
+
+    public function delete(string $field, ?string $folder = '', ?int $width = 250, ?int $heigth =250) {
+        if ($field !== 'default-avatar.png') {
+            $success = false;
+            $path = $this->params->get('images_directory').$folder;
+
+            $mini = $path.'/mini/'.$width.'x'.$heigth.'-'.$field;
+
+            if (file_exists($mini)) {
+                $success =true;
+            }
+
+            $original = $path.'/'.$field;
+
+            if (file_exists($original)) {
+                unlink($mini);
+                $success = true;
+            }
+
+            return $success;
+        }
+
+        return false;
+    }
+}

--- a/templates/post/index.html.twig
+++ b/templates/post/index.html.twig
@@ -118,18 +118,14 @@
         {% for comment in commentList %}
         <div class="d-flex justify-content-between mb-3">
             <div class="pe-3 col-2">
-                {# {% for user in users %}
-                    {% if comment.id_user is same as user.id %} #}
-                    <img id="avatar-user" class="img-fluid rounded-circle mb-4 avatar"
-                    {# {% if user.avatar is not null %} 
-                        src="{{ ROOT }}images/avatar_upload/"
-                        {% else %} #}
-                        src="../images/default/default-avatar.png" 
-                        {# {% endif %}  #}
-                        alt="..." />
-                    <h3 class="fs-5 text-center">{{ comment.user.username }}</h3>
-                    {# {% endif %}
-                {% endfor %} #}
+                <img id="avatar-user" class="img-fluid rounded-circle mb-4 avatar"
+                    {% if comment.user.avatar is not null %}
+                        src="{{ asset('images/uploads/avatars/'~ comment.user.avatar) }}"
+                    {% else %}
+                        src="{{ asset('images/default/default-avatar.png') }}"
+                    {% endif %}
+                    alt="..." />
+                <h3 class="fs-5 text-center">{{ comment.user.username }}</h3>
             </div>
             <div class="p-3 col-10 pt-5  button-deco bg-white flex-fill">
                 <p class="small text-break">{{ comment.content }}</p>

--- a/templates/security/registration.html.twig
+++ b/templates/security/registration.html.twig
@@ -17,7 +17,8 @@
 
             {{ form_row(form.username) }} 
             {{ form_row(form.email) }}
-            {{ form_row(form.plainPassword) }} 
+            {{ form_row(form.plainPassword) }}
+            {{ form_row(form.avatar) }}
             
             <div class="d-flex justify-content-center">
                 <button type="submit" class="my-3 fs-3 button-deco">Envoyer !</button>


### PR DESCRIPTION
### Comportements problématiques
Les utilisateurs n'ont pas d'avatar.

### Nouveaux comportements
On créé une propriété `avatar `dans l'entité `User`, afin de sauvegardé en base de données le nom de l'image à télécharger de nos fichiers images, afin de l'afficher à côté des commentaires associés.

### Dépendances (pull requests) :
- https://github.com/AurelieBnc/SnowTricks/pull/16
- https://github.com/AurelieBnc/SnowTricks/pull/15

## Contexte
Lors de la création des commentaires, je me suis rendue compte que j'avais oublié d'inclure l'avatar dans le formulaire d'enregistrement et dans l'entité User

# _____________ ENGLISH ___________________
### Problematic behaviors
Users do not have an avatar.

### New behaviors
We create an `avatar` property in the `User` entity, in order to save the name of the image to download from our image files in the database, in order to display it next to the associated comments.

### Dependencies (pull requests):
- https://github.com/AurelieBnc/SnowTricks/pull/16
- https://github.com/AurelieBnc/SnowTricks/pull/15

## Context
When creating comments, I realized that I forgot to include the avatar in the registration form and in the User entity