### PR TITLE
fix position route & property routes

### DIFF
--- a/src/Controller/TrickController.php
+++ b/src/Controller/TrickController.php
@@ -80,6 +80,15 @@ class TrickController extends AbstractController
         ]);
     }
 
+    #[Route('/commentList/{trick}/{loader}', name: 'complete_comment_list')]
+    public function commentListRedirect(int $trick, int $loader): Response
+    {
+        return $this->redirectToRoute('trick', [
+            'id' => $trick,
+            'loader' => 0
+        ]);
+    }
+
     #[Route('/{trick_id}/edit/headerImage', name: 'trick_edit_header_image')]
     public function editHeaderImage(int $trick_id, Request $request, EntityManagerInterface $entityManager): Response
     {
@@ -218,8 +227,8 @@ class TrickController extends AbstractController
 
     }
 
-    #[Route('/{id}/edit', name: 'trick_edit')]
-    public function editTrick(int $id, Request $request, EntityManagerInterface $entityManager, PictureService $pictureService): Response
+    #[Route('/{trick_id}/edit', name: 'trick_edit')]
+    public function editTrick(int $trick_id, Request $request, EntityManagerInterface $entityManager, PictureService $pictureService): Response
     {
         $user = $this->getUser();
 
@@ -228,7 +237,7 @@ class TrickController extends AbstractController
         $commentList = null;
 
         $trickRepo = $entityManager->getRepository(Trick::class);
-        $trick = $trickRepo->find($id);
+        $trick = $trickRepo->find($trick_id);
 
         $mediaRepo = $entityManager->getRepository(Media::class);
         $videoUrlList = $mediaRepo->videoUrlList($trick->getId());
@@ -301,15 +310,15 @@ class TrickController extends AbstractController
         ]);
     }
 
-    #[Route('/{id}/{loader}', name: 'trick')]
-    public function index(int $id, int $loader, EntityManagerInterface $entityManager, Request $request, ?UserInterface $user): Response
+    #[Route('/{trick_id}/{loader}', name: 'trick')]
+    public function index(int $trick_id, int $loader, EntityManagerInterface $entityManager, Request $request, ?UserInterface $user): Response
     {
         $pictureList = null;
         $videoUrlList = null;
         $commentList = null;
 
         $trickRepo = $entityManager->getRepository(Trick::class);
-        $trick = $trickRepo->find($id);
+        $trick = $trickRepo->find($trick_id);
 
         $mediaRepo = $entityManager->getRepository(Media::class);
         $videoUrlList = $mediaRepo->videoUrlList($trick->getId());
@@ -374,15 +383,6 @@ class TrickController extends AbstractController
             'commentList' => $commentList,
             'loader' => $loader,
             'commentForm' => $commentForm->createView()
-        ]);
-    }
-
-    #[Route('/commentList/{trick}/{loader}', name: 'complete_comment_list')]
-    public function commentListRedirect(int $trick, int $loader): Response
-    {
-        return $this->redirectToRoute('trick', [
-            'id' => $trick,
-            'loader' => 0
         ]);
     }
 }

--- a/templates/home/home.html.twig
+++ b/templates/home/home.html.twig
@@ -33,7 +33,7 @@
     {% for trick in trickList %}
     
     <div class="card ms-auto col-12 col-lg-2 m-3 p-0">
-        <a href= "{{ path('trick', {'id': trick.id, 'loader': 1}) }}">
+        <a href= "{{ path('trick', {'trick_id': trick.id, 'loader': 1}) }}">
         {% if trick.headerImage is not null %} 
             <img src="{{ asset('images/uploads/trickImages/mini/250x250-'~ trick.headerImage) }}" class="card-img-top m-auto" alt="...">
         {% elseif trick.pictureList is not empty %}
@@ -52,10 +52,10 @@
         <div class="d-sm-none d-lg-block">
             <div class="card-footer d-flex justify-content-end align-items-end p-0 border-top">   
                 <p class="px-3 m-0" >
-                    <a href="{{ path('trick_edit', {'id': trick.id}) }}"><i class="fa-solid fa-pencil" style="color: #D9C7A6;"></i></a>
+                    <a href="{{ path('trick_edit', {'trick_id': trick.id}) }}"><i class="fa-solid fa-pencil" style="color: #D9C7A6;"></i></a>
                 </p>
                 <p class="px-2 m-0">
-                    <a href="{{ path('trick_edit', {'id': trick.id}) }}"><i class="fa-solid fa-trash" style="color: #B04C46;"></i></a>
+                    <a href="{{ path('trick_edit', {'trick_id': trick.id}) }}"><i class="fa-solid fa-trash" style="color: #B04C46;"></i></a>
                 </p>
             </div>            
         </div>

--- a/templates/trick/trick.html.twig
+++ b/templates/trick/trick.html.twig
@@ -14,7 +14,7 @@
             <div class="d-sm-none d-lg-block">
                 <div class="d-flex justify-content-end align-items-end p-0">   
                     <p class="px-2 m-0 bg-edit-button button-deco" >
-                        <a href="{{ path('trick_edit', {'id': trick.id}) }}"><i class="fa-solid fa-pencil" style="color: #D9C7A6;"></i></a>
+                        <a href="{{ path('trick_edit', {'trick_id': trick.id}) }}"><i class="fa-solid fa-pencil" style="color: #D9C7A6;"></i></a>
                     </p>
                     <p class="px-2 m-0 bg-edit-button button-deco">
                         <a href=""><i class="fa-solid fa-trash" style="color: #B04C46;"></i></a>
@@ -23,7 +23,7 @@
             </div>
             <div class="d-flex justify-content-end align-items-end p-0">
                 <p class="d-lg-none px-2 m-0 bg-edit-button button-deco">
-                    <a href="{{ path('trick_edit', {'id': trick.id}) }}"><i id="pencil-icon" class="fa-solid fa-pencil p-2" style="color: #D9C7A6;"></i></a>
+                    <a href="{{ path('trick_edit', {'trick_id': trick.id}) }}"><i id="pencil-icon" class="fa-solid fa-pencil p-2" style="color: #D9C7A6;"></i></a>
                 </p>
                 <p class="d-lg-none px-2 m-0 bg-edit-button button-deco">
                     <a href=""><i id="trash-icon" class="fa-solid fa-trash p-2" style="color: #B04C46;"></i></a>


### PR DESCRIPTION
### Comportements problématiques
La route `complete_comment_list` ne suis pas la logique symfony, la première partie de son chemin url étant écris en dur, elle doit se positionner avant celle contenant une variable.
Les variables des routes ne sont pas toutes constantes.

### Nouveaux comportements
Réaffectation de la route `complete_comment_list` avant les routes commençant par une variable.
Harmonisation des noms de variables des routes {id} -> {trick-id}

### Issue
- https://github.com/AurelieBnc/SnowTricks/issues/21

# _____________ ENGLISH ___________________
### New behaviors
Reassigned route `complete_comment_list` before routes starting with a variable.
Harmonization of route variable names {id} -> {trick-id}

### Issue
- https://github.com/AurelieBnc/SnowTricks/issues/21
