### PR TITLE
unique property title 's Trick

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -8,7 +8,7 @@ when@dev:
             main:
                 type: stream
                 path: "%kernel.logs_dir%/%kernel.environment%.log"
-                level: debug
+                level: info
                 channels: ["!event"]
             # uncomment to get logging in your browser
             # you may have to allow bigger header sizes in your Web server configuration
@@ -24,7 +24,7 @@ when@dev:
                 channels: ["!event", "!doctrine", "!console"]
             syslog_handler:
                 type: syslog
-                level: debug
+                level: info
 
 when@test:
     monolog:

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -6,3 +6,8 @@ when@test:
     twig:
         strict_variables: true
         cache: false
+        
+when@dev:
+    twig:
+        strict_variables: true
+        cache: false

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -149,6 +149,12 @@ body, html {
     font-family: 'Retroking','Roboto','Arial','Helvetica','sans-serif' ;
 }
 
+.comment-deco {
+    border: solid var(--darkcolor) !important;
+    font-weight: bold !important;
+    font-family: 'Roboto','Arial','Helvetica','sans-serif' !important ;
+}
+
 #avatar-user {
     height: 100px;
 }

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -25,7 +25,7 @@ class HomeController extends AbstractController
                 $this->redirectToRoute('app_home');
             }
         }
-
+        /** @var App\Repository\TrickRepository $repo */
         $repo = $entityManager->getRepository(Trick::class);
         $trickList = $repo->trickListMaxFifteen();
         $countTrickList = $repo->countTrickList();

--- a/src/Controller/TrickController.php
+++ b/src/Controller/TrickController.php
@@ -210,7 +210,7 @@ class TrickController extends AbstractController
                 $entityManager->flush();
 
                 return $this->redirectToRoute('trick_edit', [
-                    'id' => $trick->getId(),
+                    'trick_id' => $trick->getId(),
                 ]);
             } 
         } else {
@@ -293,7 +293,7 @@ class TrickController extends AbstractController
                 $this->addFlash('success', 'Ton trick a bien été modifié !');
 
                 return $this->redirectToRoute('trick_edit', [
-                    'id' => $trick->getId(),
+                    'trick_id' => $trick->getId(),
                 ]);
             } 
         } else {
@@ -355,7 +355,7 @@ class TrickController extends AbstractController
                 if ($user->isVerified() === false) {
                     $this->addFlash('verification', 'Vous devez confirmer votre adresse email.');
                     $this->redirectToRoute('trick', [
-                        'id' => $trick->getId(),
+                        'trick_id' => $trick->getId(),
                         'loader' => $loader
                     ]);
                 }
@@ -368,7 +368,7 @@ class TrickController extends AbstractController
                 $this->addFlash('success', 'Ton commentaire a bien été envoyé !');
 
                 return $this->redirectToRoute('trick', [
-                    'id' => $trick->getId(),
+                    'trick_id' => $trick->getId(),
                     'loader' => $loader
                 ]);
             } 

--- a/src/Entity/Trick.php
+++ b/src/Entity/Trick.php
@@ -3,12 +3,14 @@
 namespace App\Entity;
 
 use App\Repository\TrickRepository;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: TrickRepository::class)]
+#[UniqueEntity(fields: ['title'], message: 'Un trick avec le même titre existe déjà.')]
 class Trick
 {
     #[ORM\Id]
@@ -16,7 +18,7 @@ class Trick
     #[ORM\Column]
     private ?int $id = null;
 
-    #[ORM\Column(length: 255)]
+    #[ORM\Column(length: 255, unique: true)]
     private ?string $title = null;
 
     #[ORM\Column(type: Types::TEXT)]

--- a/templates/trick/trick.html.twig
+++ b/templates/trick/trick.html.twig
@@ -128,7 +128,7 @@
                     alt="..." />
                 <h3 class="fs-5 text-center">{{ comment.user.username }}</h3>
             </div>
-            <div class="p-3 col-10 pt-5  button-deco bg-white flex-fill">
+            <div class="p-3 col-10 pt-5 comment-deco bg-white flex-fill">
                 <p class="small text-break">{{ comment.content }}</p>
                 <p class="blockquote-footer d-flex justify-content-end mt-2">Le {{ comment.createdAt | date("d/m/Y",
                     "Europe/Paris") }}</p>


### PR DESCRIPTION
### Comportements problématiques
Plusieurs Trick peuvent avoir le même titre

### Nouveaux comportements
Ajout d'une assertion sur le titre des Trick, afin qu'il soit unique.

### Issue
- https://github.com/AurelieBnc/SnowTricks/issues/21

## Autres
fix des routes: la propriété id, n'avait pas été modifier dans tous les render en tant que trick_id et créaient un message d'erreur

# _____________ ENGLISH ___________________
### Problematic behaviors
Several Tricks can have the same title

### New behaviors
Added an assertion to the Trick title, so that it is unique.

### Issue
- https://github.com/AurelieBnc/SnowTricks/issues/21

## Others
fix routes: the id property had not been modified in all renders as trick_id and created an error message