### PR TITLE
fix display delete button on createFormTrick

### DIFF
--- a/templates/trick/create_trick.html.twig
+++ b/templates/trick/create_trick.html.twig
@@ -6,11 +6,6 @@
 {% endblock %}
 
 {% block body %}
-{# {% if error %}
-<div class="col-8 d-flex flex-column justify-content-center alert alert-danger text-center fw-bold m-auto my-3">
-    Une erreur est survenue.
-</div>
-{% endif %} #}
 
 <div class="d-sm-none d-lg-block">
     <h1 class="m-auto my-5 d-flex align-items-end justify-content-center text-center">
@@ -36,13 +31,12 @@
         {{ form_row(trickForm.pictureList) }}
         {{ form_label(trickForm.media) }} <img src="{{ asset('images/logo/youtube-logo.png') }}" id="youtube-logo" class="card-img-top m-auto pb-1 ps-1" alt="...">
         {{ form_widget(trickForm.media) }} 
-
-            
+       
         <div class="d-flex justify-content-center">
-            <button type="submit" class="my-3 fs-3 button-deco">            
-                Ajouter un nouveau trick
-            </button>
+            {{ form_row(trickForm.save)}}
         </div>
+
+        {{ form_row(trickForm.delete, {'attr': {'style': 'display: none;'}}) }}
 
         {{ form_end(trickForm) }}
 


### PR DESCRIPTION
### Comportements problématiques
La modification lors de la PR feat-delete a amené à ajouter deux boutons dans le TrickFormType. Sur le template CreateForm il y avait déjà un bouton de sauvegarde et donc affichait au final 3 boutons.

### Nouveaux comportements
Un seule bouton sauvegarder apparait et le bouton delete est caché dans le formulaire de création de Trick.

### PR dépendance
- https://github.com/AurelieBnc/SnowTricks/pull/32

### Issue
- https://github.com/AurelieBnc/SnowTricks/pull/26

# _____________ ENGLISH ___________________
### Problematic behaviors
The modification during the PR feat-delete led to adding two buttons in the TrickFormType. On the CreateForm template there was already a save button and therefore ultimately displayed 3 buttons.

### New behaviors
A single save button appears and the delete button is hidden in the Trick creation form.

### PR dependency
- https://github.com/AurelieBnc/SnowTricks/pull/32

### Issue
- https://github.com/AurelieBnc/SnowTricks/pull/26