### PR TITLE
Feat security authorization

### DIFF
--- a/src/Controller/TrickController.php
+++ b/src/Controller/TrickController.php
@@ -481,13 +481,6 @@ class TrickController extends AbstractController
         if ($user) {
             $commentForm->handleRequest($request);
             if ($commentForm->isSubmitted() && $commentForm->isValid()) {
-
-                if ($user->isVerified() === false) {
-                    $this->addFlash('verification', 'Tu dois confirmer ton adresse email.');
-                    $this->redirectToRoute('trick', [
-                        'slug' => $trick->getSlug(),
-                    ]);
-                }
                 $comment->setCreatedAt(new \DateTimeImmutable())
                     ->setTrick($trick)
                     ->setUser($user);

--- a/src/Security/Voter/HeaderImageVoter.php
+++ b/src/Security/Voter/HeaderImageVoter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Security\Voter;
+
+use App\Entity\Trick;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class HeaderImageVoter extends Voter
+{
+    public const EDIT = 'HEADER_IMAGE_EDIT';
+    public const DELETE = 'HEADER_IMAGE_DELETE';
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        return in_array($attribute, [self::EDIT, self::DELETE])
+            && $subject instanceof Trick;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+        if (!$user instanceof UserInterface) {
+            return false;
+        }
+        
+        $userRoles = $user->getRoles();
+
+        return $attribute === self::EDIT || $attribute === self::DELETE
+        ? in_array('ROLE_ADMIN', $userRoles)
+        : false;
+    }
+}

--- a/src/Security/Voter/MediaVoter.php
+++ b/src/Security/Voter/MediaVoter.php
@@ -2,20 +2,20 @@
 
 namespace App\Security\Voter;
 
-use App\Entity\Trick;
+use App\Entity\Media;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-class TrickVoter extends Voter
+class MediaVoter extends Voter
 {
-    public const EDIT = 'TRICK_EDIT';
-    public const DELETE = 'TRICK_DELETE';
+    public const EDIT = 'MEDIA_EDIT';
+    public const DELETE = 'MEDIA_DELETE';
 
     protected function supports(string $attribute, mixed $subject): bool
     {
         return in_array($attribute, [self::EDIT, self::DELETE])
-            && $subject instanceof Trick;
+            && $subject instanceof Media;
     }
 
     protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
@@ -31,5 +31,4 @@ class TrickVoter extends Voter
         ? in_array('ROLE_ADMIN', $userRoles)
         : false;
     }
-
 }

--- a/src/Security/Voter/PictureVoter.php
+++ b/src/Security/Voter/PictureVoter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Security\Voter;
+
+use App\Entity\Picture;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class PictureVoter extends Voter
+{
+    public const EDIT = 'PICTURE_EDIT';
+    public const DELETE = 'PICTURE_DELETE';
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        return in_array($attribute, [self::EDIT, self::DELETE])
+            && $subject instanceof Picture;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+        if (!$user instanceof UserInterface) {
+            return false;
+        }
+        
+        $userRoles = $user->getRoles();
+
+        return $attribute === self::EDIT || $attribute === self::DELETE
+        ? in_array('ROLE_ADMIN', $userRoles)
+        : false;
+    }
+}

--- a/src/Security/Voter/TrickVoter.php
+++ b/src/Security/Voter/TrickVoter.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Security\Voter;
+
+use App\Entity\Trick;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class TrickVoter extends Voter
+{
+    public const CREATE = 'TRICK_CREATE';
+    public const EDIT = 'TRICK_EDIT';
+    public const DELETE = 'TRICK_DELETE';
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        return in_array($attribute, [self::CREATE, self::EDIT, self::DELETE])
+            && $subject instanceof Trick;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+        if (!$user instanceof UserInterface) {
+            return false;
+        }
+        
+        $userRoles = $user->getRoles();
+
+        switch ($attribute) {
+            case self::CREATE:
+               return in_array('ROLE_ADMIN', $userRoles);
+                break;
+            case self::EDIT:
+                return in_array('ROLE_ADMIN', $userRoles);
+                break;
+            case self::DELETE:
+               return in_array('ROLE_ADMIN', $userRoles);
+                break;
+        }
+
+        return false;
+    }
+
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -23,12 +23,14 @@
                 <li class="nav-item">
                     <a class="nav-link active pe-2" aria-current="page" href="{{ path("app_home") }}">Accueil</a>
                 </li>
+                {% if is_granted('ROLE_ADMIN') %}
                 <li class="nav-item">
                     <a class="nav-link pe-2" href="{{ path("trick_create") }}">Ajouter un Trick</a>
                 </li>
+                {% endif %}
                 {% if not is_granted('IS_AUTHENTICATED') %}
                 <li class="nav-item">
-                    <a class="nav-link pe-2" href="{{ path("security_registration") }}">Connexion</a>
+                    <a class="nav-link pe-2" href="{{ path("app_login") }}">Connexion</a>
                 </li>
                 {% else %}
                 <li class="nav-item">
@@ -67,7 +69,6 @@
                             class="fa-solid fa-house p-2"></i></a></li>
                 <li class="nav-item"><a class="nav-link" href="{{ path("trick_create") }}" title="Ajout Stricks"><i id="bookmark-icon"
                             class="fa-solid fa-bookmark p-2"></i></a></li>
-                {# if not app.user #}
                 {% if not is_granted('IS_AUTHENTICATED') %}
                 <li class="nav-item"><a class="nav-link" href="{{ path("security_registration") }}" title="Connexion"><i id="bracket-icon" class="fa-solid fa-right-to-bracket p-2"></i></a></li>
                 {% else %}

--- a/templates/home/home.html.twig
+++ b/templates/home/home.html.twig
@@ -48,6 +48,7 @@
                 <h3 class="card-text  p-2 pb-0">{{ trick.title }}</h3>
             <h3 class="d-lg-none card-text pt-3 ps-3" style="font-size: 5rem;">{{ trick.title }}</h3>
         </div>
+        {% if is_granted('ROLE_ADMIN') %}
         <div class="d-sm-none d-lg-block">
             <div class="card-footer d-flex justify-content-end align-items-end p-0 border-top">   
                 <p class="px-3 m-0" >
@@ -62,6 +63,7 @@
                 </p>
             </div>            
         </div>
+        {% endif %}
 
         <div class="card-footer d-flex justify-content-end align-items-end p-0 border-top">
             <p class="d-lg-none px-5 m-0">

--- a/templates/login/login.html.twig
+++ b/templates/login/login.html.twig
@@ -16,7 +16,7 @@
 
     <div class="my-5 col-12 col-lg-8 m-auto">
         <div class="pt-5 px-5 justify-content-around bg-light-form shadow pb-3">
-            <form action="{{ path('app_login') }}" method="post" class="d-flex flex-column">
+            <form action="{{ path('app_login') }}" method="post" class="my-3 d-flex flex-column">
                 
                 <div class="mb-3">
                     <label for="username" class="form-label fw-bold fs-1 d-flex justify-content-center">Email</label>
@@ -29,15 +29,19 @@
                 </div>
 
                 <input type="hidden" name="_target_path" value="{{ path('app_home') }}">
-
                 <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}">
-                
 
                 <div class="d-flex justify-content-center">
-                    <button type="submit" class="my-3 fs-3 button-deco">Je me connecte</button>
+                    <button type="submit" class="my-3 p-3 fs-2 button-deco">Connexion</button>
                 </div>
+
             </form>
-            <a href="{{ path('app_forgot_password_request') }}" class="text-decoration-none fw-medium fst-italic text-black d-flex justify-content-end">J'ai oublié mon mot de passe</a>
+
+            <div class="mt-5 mb-3 d-flex justify-content-between">
+                <a href="{{ path('security_registration') }}" class="text-decoration-none fw-medium fst-italic text-black d-flex justify-content-end">Je n'ai pas encore de compte!</a>
+                <a href="{{ path('app_forgot_password_request') }}" class="text-decoration-none fw-medium fst-italic text-black d-flex justify-content-end">J'ai oublié mon mot de passe ...</a>
+            </div>
+
         </div>
     </div>
     {% endblock %}

--- a/templates/trick/trick.html.twig
+++ b/templates/trick/trick.html.twig
@@ -10,6 +10,8 @@
 {% else %}
     <div id="bg-trick1" style="background-image: url('{{ asset('images/background/snowboard1.jpg') }}');" class="row text-center m-0 p-0">
 {% endif %}
+
+        {% if is_granted('ROLE_ADMIN') %}
         <div class="p-3">
             <div class="d-sm-none d-lg-block">
                 <div class="d-flex justify-content-end align-items-end p-0">   
@@ -37,7 +39,11 @@
                     </a>
                 </p>
             </div>
-        </div>    
+        </div> 
+        {% else %}
+        <div style="height:400px;"></div>
+        {% endif %}
+
         <div class="d-sm-none d-lg-block">
             <h2 class="fs-1 col-4 m-auto d-flex align-items-end justify-content-center text-center bg-edit-button">{{ trick.title }}</h2>
         </div>
@@ -55,7 +61,7 @@
         {% endfor %}
         {% for link in videoUrlList %}
         <div class="col-12 col-lg-2 mx-auto mx-lg-3 my-lg-3 p-0">
-            <iframe height="315" class="card-img-top m-auto img-fluid img-thumbnail" src="{{ link.videoUrl }}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+            <iframe height="315" class="card-img-top m-auto img-fluid img-thumbnail" src="{{ link }}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
         </div>
         {% endfor %}
     </div>


### PR DESCRIPTION
### Ancien comportement
On charge par défaut les 10 premiers commentaires, si le nombre total de commentaire est supérieur à 10 un bouton s'affiche. Il permet d'envoyer une nouvelle requête au repository de Comment, afin d'envoyer tous les commentaires.

### Nouveaux comportements
On sécurise les accès à certaines routes, méthodes ou fonctionnalités selon le rôle de l'utilisateur: 
- l'onglet de navigation "ajouter un trick" et les boutons de modération des tricks sont cachés pour les utilisateurs n'ayant pas le rôle admin
- les méthodes editTrick et deleteTrick sont bloqués avec le TrickVoter
- les méthodes editMedia et deleteMedia sont bloqués avec le MediaVoter
- les méthodes editPicture et deletePicture sont bloquées avec le PictureVoter
- les méthodes editHeaderImage et deleteHeaderImage sont bloquées avec le HeaderImageVoter.
- l'envoi de commentaire est bloqué pour les utilisateurs non connecté et non vérifié

### Issue
- https://github.com/AurelieBnc/SnowTricks/issues/8


## _____________ ENGLISH ___________________
### Old behavior
The first 10 comments are loaded by default, if the total number of comments is greater than 10 a button is displayed. It allows you to send a new request to the Comment repository, in order to send all comments.

### New behaviors
We secure access to certain routes, methods or functionalities according to the user's role:
- the "add a trick" navigation tab and the trick moderation buttons are hidden for users who do not have the admin role
- the editTrick and deleteTrick methods are blocked with the TrickVoter
- the editMedia and deleteMedia methods are blocked with MediaVoter
- the editPicture and deletePicture methods are blocked with the PictureVoter
- the editHeaderImage and deleteHeaderImage methods are blocked with the HeaderImageVoter.
- sending comments is blocked for unconnected and unverified users

### Issue
- https://github.com/AurelieBnc/SnowTricks/issues/8