### PR TITLE
Fix fake token for forgotten password

### DIFF
--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -176,8 +176,10 @@ class SecurityController extends AbstractController
                 ]);
 
             } else {
-                //todo: gérer le fait qu'il n'y a pas d'utilisateur de façon sécuriser (redirect sur le template de réussite de l'envoi du mail)
-                // générer un faux token
+                $resetToken = $tokenGeneratorInterface->generateToken();
+                return $this->render('security/check_email.html.twig', [
+                    'resetToken' => $resetToken,
+                ]);
             }
 
         }


### PR DESCRIPTION
### Comportements problématiques
Les mauvaises adresses email ne sont pas gérée lors de la demande de réinitialisation de mot de passe.

### Nouveaux comportements
Un faux token est généré et l'utilisateur est redirigé sur la page de confirmation d'envoi d'email.

### Issue
- https://github.com/AurelieBnc/SnowTricks/issues/5

# _____________ ENGLISH ___________________
### Problematic behaviors
Bad email addresses are not handled when requesting a password reset.

### New behaviors
A fake token is generated and the user is redirected to the email sending confirmation page.

### Issue
- https://github.com/AurelieBnc/SnowTricks/issues/5