### PR TITLE
Fix diverse

### DIFF
--- a/src/Service/AvatarService.php
+++ b/src/Service/AvatarService.php
@@ -13,7 +13,7 @@ Class AvatarService
 
 
     public function __construct(        
-        #[Autowire('%trick.picture.folder%')]
+        #[Autowire('%avatar.picture.folder%')]
         private string $folder,
         #[Autowire('%images_directory%')]
         private string $imgDirectory,
@@ -29,7 +29,7 @@ Class AvatarService
             mkdir($path.'/', 0755, true);
         }
 
-        $field = md5(uniqId(rand(), true)).'.png';
+        $imageName = md5(uniqId(rand(), true)).'.png';
         $pictureDatas = getImageSize($picture);
 
         if ($pictureDatas === false) {
@@ -73,8 +73,8 @@ Class AvatarService
 
         $resizePicture = imagecreatetruecolor($this->width, $this->heigth);
         imagecopyresampled($resizePicture, $pictureSource, 0, 0, $src_x, $src_y, $this->width, $this->heigth, $squareSize, $squareSize);
-        imagepng($resizePicture, $path.'/'.$this->width.'x'.$this->heigth.'-'.$field);
+        imagepng($resizePicture, $path.'/'.$this->width.'x'.$this->heigth.'-'.$imageName);
 
-        return $field;
+        return $imageName;
     }
 }

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -60,7 +60,7 @@
     <footer>
         <nav id="footer-desk" class="navbar fixed-bottom bg-dark border-body d-none d-lg-block" data-bs-theme="dark">
             <div class="container-fluid d-flex justify-content-center">
-                <span class="navbar-brand m-0">Footer</span>
+                <span class="navbar-brand m-0">© 2024 Copyright - Shil</span>
             </div>
         </nav>
         <nav id="footer-phone" class="navbar fixed-bottom bg-dark border-body d-block d-lg-none">
@@ -79,7 +79,7 @@
                 {% endif %}
                 {% if not is_granted('IS_AUTHENTICATED') %}
                 <li class="nav-item">
-                    <a class="nav-link" href="{{ path("security_registration") }}" title="Connexion">
+                    <a class="nav-link" href="{{ path("app_login") }}" title="Connexion">
                         <i id="bracket-icon" class="fa-solid fa-right-to-bracket"></i>
                     </a>
                 </li>

--- a/templates/home/home.html.twig
+++ b/templates/home/home.html.twig
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block body %}
-<h2 id="tricks-list" class="text-center my-5">Liste des Tricks</h2>
+<h2 id="tricks-list" class="text-center p-3 my-3">Liste des Tricks</h2>
 
 {% if trickList|length > 0 %}
 <section class="row d-flex col-12 pb-5">


### PR DESCRIPTION
### Comportements problématiques
Le service de gestion d'avatar n'enregistrait pas l'image dans le bon dossier.
Le titre "liste des Tricks" était trop coller au bord de l'écran après avoir cliquer sur la flèche d'ancre.
Le lien pour se connecter du footer renvoyait vers la page d'enregistrement et non vers la page de connexion comme le menu de haut de page.

### Nouveaux comportements
Les comportements problématiques ont été corrigés.

# _____________ ENGLISH ___________________
### Problematic behaviors
The avatar management service was not saving the image in the correct folder.
The title "Tricks list" was sticking too much to the edge of the screen after clicking on the anchor arrow.
The link to log in in the footer referred to the registration page and not to the login page like the top menu.

### New behaviors
Problematic behaviors have been corrected.